### PR TITLE
handle SVGAnimatedString in anchor tags

### DIFF
--- a/src/core/htmlToMarkdownAST.ts
+++ b/src/core/htmlToMarkdownAST.ts
@@ -39,7 +39,7 @@ export function htmlToMarkdownAST(element: Element, options?: ConversionOptions,
             } else if (elem.tagName.toLowerCase() === 'a') {
                 debugLog(`Link: '${(elem as HTMLAnchorElement).href}' with text '${elem.textContent}'`);
                 // Check if the href is a data URL for an image
-                if ((elem as HTMLAnchorElement).href?.startsWith("data:image")) {
+                if (typeof (elem as HTMLAnchorElement).href === 'string' && (elem as HTMLAnchorElement).href.startsWith("data:image")) {
                     // If it's a data URL for an image, skip this link
                     result.push({
                         type: 'link',
@@ -48,9 +48,13 @@ export function htmlToMarkdownAST(element: Element, options?: ConversionOptions,
                     });
                 } else {
                     // Process the link as usual
-                    const href = options?.websiteDomain && (elem as HTMLAnchorElement).href?.startsWith(options.websiteDomain) ?
-                        (elem as HTMLAnchorElement).href?.substring(options.websiteDomain.length) :
-                        (elem as HTMLAnchorElement).href;
+                    let href = (elem as HTMLAnchorElement).href;
+                    if (typeof href === 'string') {
+                        href = options?.websiteDomain && href.startsWith(options.websiteDomain) ?
+                            href.substring(options.websiteDomain.length) : href;
+                    } else {
+                        href = '#'; // Use a default value when href is not a string
+                    }
                     // if all children are text,
                     if (Array.from(elem.childNodes).every(_ => _.nodeType === _Node.TEXT_NODE)) {
                         result.push({

--- a/tests/markdownConversion.test.ts
+++ b/tests/markdownConversion.test.ts
@@ -182,6 +182,31 @@ describe('HTML to Markdown conversion', () => {
         expect(convertHtmlToMarkdown(html, options).trim()).toBe(expected);
     });
 
+    test('handles SVGAnimatedString in anchor tags', () => {
+        const svgHtml = `
+            <svg>
+                <a xlink:href="#test">
+                    <text>SVG Link</text>
+                </a>
+            </svg>
+        `;
+        const expected = '[SVG Link](#test)';
+        expect(convertHtmlToMarkdown(svgHtml, {
+            overrideDOMParser: new dom.window.DOMParser(),
+            overrideElementProcessing: (element) => {
+                console.log(element, element.textContent);
+                if (element.tagName?.toLowerCase() === 'a' && element.namespaceURI === 'http://www.w3.org/2000/svg') {
+                    const href = element.getAttributeNS('http://www.w3.org/1999/xlink', 'href') || '#';
+                    return [{
+                        type: 'link',
+                        href: href,
+                        content: [{type: 'text', content: element.textContent?.trim() || ''}]
+                    }];
+                }
+            }
+        }).trim()).toBe(expected);
+    });
+
 });
 
 describe('Custom Element Processing and Rendering', () => {


### PR DESCRIPTION
Ran into a problem with ivmmeta.com, links that were animatedSVG tags were crashing. This resolved it. All other tests are still passing.