### PR TITLE
fix nested links inside formatting

### DIFF
--- a/src/core/htmlToMarkdownAST.ts
+++ b/src/core/htmlToMarkdownAST.ts
@@ -241,21 +241,30 @@ export function htmlToMarkdownAST(element: Element, options?: ConversionOptions,
                     case 'b':
                         if (content) {
                             debugLog(`Bold: '${content}'`);
-                            result.push({type: 'bold', content});
+                            result.push({
+                                type: 'bold',
+                                content: htmlToMarkdownAST(elem, options, indentLevel + 1)
+                            });
                         }
                         break;
                     case 'em':
                     case 'i':
                         if (content) {
                             debugLog(`Italic: '${content}'`);
-                            result.push({type: 'italic', content});
+                            result.push({
+                                type: 'italic',
+                                content: htmlToMarkdownAST(elem, options, indentLevel + 1)
+                            });
                         }
                         break;
                     case 's':
                     case 'strike':
                         if (content) {
                             debugLog(`Strikethrough: '${content}'`);
-                            result.push({type: 'strikethrough', content});
+                            result.push({
+                                type: 'strikethrough',
+                                content: htmlToMarkdownAST(elem, options, indentLevel + 1)
+                            });
                         }
                         break;
                     case 'code':

--- a/src/types/markdownTypes.ts
+++ b/src/types/markdownTypes.ts
@@ -1,14 +1,14 @@
 export type BoldNode = {
     type: 'bold';
-    content: string;
+    content: string | SemanticMarkdownAST[];
 };
 export type ItalicNode = {
     type: 'italic';
-    content: string;
+    content: string | SemanticMarkdownAST[];
 };
 export type StrikethroughNode = {
     type: 'strikethrough';
-    content: string;
+    content: string | SemanticMarkdownAST[];
 };
 // Define heading levels
 export type HeadingNode = {

--- a/tests/markdownConversion.test.ts
+++ b/tests/markdownConversion.test.ts
@@ -253,6 +253,18 @@ describe('HTML to Markdown conversion', () => {
         }).trim()).toBe(expected);
     });
 
+    test("converts nested strong and anchor tags", () => {
+        const html =
+            '<p><strong><a href="https://example.com/" rel>example link:</a><span> </span></strong><span>Additional text</span></p>';
+        const expected =
+            "**[example link:](https://example.com/)** Additional text";
+        expect(
+            convertHtmlToMarkdown(html, {
+                overrideDOMParser: new dom.window.DOMParser(),
+            }).trim()
+        ).toBe(expected);
+    });
+    
 });
 
 describe('Custom Element Processing and Rendering', () => {


### PR DESCRIPTION
Replaces [this pr](https://github.com/romansky/dom-to-semantic-markdown/pull/17) (i fubared the git history, so this one's fresh)

The last change requested had to do with adding trailing spaces which shouldn't have been necessary but the original solution had nested and incorrect logic for adding initial spaces so the adding of trailing spaces was a kludge. This is now fixed by restoring the logic for adding initial spaces to it's original position (and having correct regexes to inspect the state of the in-progress markdown and content being processed).